### PR TITLE
Add an installation dependency on feedparser

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ rawdog has the following dependencies:
 - PyTidyLib 0.2.1 or later (optional but strongly recommended)
 
 To install rawdog on your system, use distutils -- "python setup.py
-install". This will install the "rawdog" command and the "rawdoglib"
+install". This will install feedparser, the "rawdog" command, and the "rawdoglib"
 Python module that it uses internally. (If you want to install to a
 non-standard prefix, read the help provided by "python setup.py install
 --help".)

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name="rawdog",
 	url="https://github.com/echarlie/rawdog-py3"
 	scripts=['rawdog'],
 	data_files=[('share/man/man1', ['rawdog.1'])],
+	install_requires=['feedparser'],
 	packages=['rawdoglib'],
 	classifiers=[
 		"Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
It's just a little more user-friendly to have setup.py install feedparser automatically.