### PR TITLE
support current version of feedarser module, enabling python 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ behaviour is highly customisable using plugins written in Python.
 rawdog has the following dependencies:
 
 - Python 3
-- feedparser 5.1.2, less than 6.0
+- feedparser 5.1.2
 - PyTidyLib 0.2.1 or later (optional but strongly recommended)
 
 To install rawdog on your system, use setuptools -- `python setup.py

--- a/rawdoglib/rawdog.py
+++ b/rawdoglib/rawdog.py
@@ -52,9 +52,9 @@ try:
 except:
 	mxtidy = None
 
-# The sanitisation code was restructured in feedparser 5.3.
+# The sanitisation code was restructured in feedparser 6.
 try:
-	_resolveRelativeURIs = feedparser.urls._resolveRelativeURIs
+	_resolveRelativeURIs = feedparser.urls.resolve_relative_uris
 except AttributeError:
 	_resolveRelativeURIs = feedparser._resolveRelativeURIs
 try:
@@ -502,14 +502,14 @@ class Feed:
 		# Turn off content-cleaning, as we need the original content
 		# for hashing and we'll do this ourselves afterwards.
 		if hasattr(feedparser, "api"):
-			# feedparser >= 5.3
+			# feedparser > 5.2
 			parse_args["sanitize_html"] = False
 			parse_args["resolve_relative_uris"] = False
 		else:
-			# feedparser < 5.3
+			# feedparser <= 5.2
 			feedparser.RESOLVE_RELATIVE_URIS = 0
 			feedparser.SANITIZE_HTML = 0
-			# Microformat support (removed in 5.3) tends to return
+			# Microformat support (removed in version 6) tends to return
 			# poor-quality data, and relies on BeautifulSoup which
 			# is unable to parse many feeds.
 			feedparser.PARSE_MICROFORMATS = 0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name="rawdog",
 	scripts=['rawdog'],
 	data_files=[('share/man/man1', ['rawdog.1'])],
 	python_requires='>=3',
-	install_requires=['feedparse>5.1.2'],
+	install_requires=['feedparser>5.1.2'],
 	packages=['rawdoglib'],
 	classifiers=[
 		"Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name="rawdog",
 	scripts=['rawdog'],
 	data_files=[('share/man/man1', ['rawdog.1'])],
 	python_requires='>=3',
-	install_requires=['feedparser>5.1.2,<6'],
+	install_requires=['feedparse>5.1.2'],
 	packages=['rawdoglib'],
 	classifiers=[
 		"Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
commit df658c3 added some forward-compatibility with the then-current development version of feedparser, which it assumed would be released as feedparser 5.3.

As it turned out, the next feedparser release was 6.0.0, which included another renaming of the `_resolveRelativeURIs` function to `resolve_relative_uris`.

This commit adjusts the forward-compatibility code for that renaming, corrects some comments referring to "feedparser 5.3" (which does not exist, see above), and removes the `<6` constraint added to the feedparser dependency by commit fa799c2e.

Being able to use feedparser version 6 is helpful because earlier versions of that module fail to import with python >= 3.9: https://github.com/kurtmckee/feedparser/issues/201