### PR TITLE
fix crash in writing outputs when two feeds have the same name

### DIFF
--- a/rawdoglib/rawdog.py
+++ b/rawdoglib/rawdog.py
@@ -1735,12 +1735,11 @@ __feeditems__
 		"""Write the feed list."""
 		bits = {}
 
-		feeds = [(feed.get_html_name(config).lower(), feed)
-		         for feed in list(self.feeds.values())]
-		feeds.sort()
+		feeds = list(self.feeds.values())
+		feeds.sort(key=lambda feed: feed.get_html_name(config).lower())
 
 		feeditems = StringIO()
-		for key, feed in feeds:
+		for feed in feeds:
 			self.write_feeditem(feeditems, feed, config)
 		bits["feeditems"] = feeditems.getvalue()
 		feeditems.close()


### PR DESCRIPTION
In order to sort the feeds by name, we generated a list of `(name, feed)` pairs, where feed is an instance of the `Feed` class, and sorted that.

When two feeds have the same name, the sorting operation falls back to comparing the `Feed` instances, even though no ordering is defined for that class. In python 2, that's harmless, but in python 3 it results in

    TypeError: '<' not supported between instances of 'Feed' and 'Feed'

The fix is to simplify the sorting code to work on a plain list of `Feed` instances, using a key function to compare them by name.

This bug could be triggered by duplicate entries in the rawdog configuration file, and also by the "numthreads 4" test in the test suite.