### PR TITLE
fix crash when using HTTP basic auth to fetch a feed

### DIFF
--- a/rawdoglib/rawdog.py
+++ b/rawdoglib/rawdog.py
@@ -386,7 +386,7 @@ class BasicAuthProcessor(urllib.request.BaseHandler):
 	for a 401/407 response first.)"""
 
 	def __init__(self, user, password, proxy=False):
-		self.auth = base64.b64encode(user + ":" + password)
+		self.auth = base64.b64encode((user + ":" + password).encode()).decode()
 		if proxy:
 			self.header = "Proxy-Authorization"
 		else:


### PR DESCRIPTION
Loading a feed configured with a "user" and "password" failed with the error

      File ".../rawdoglib/rawdog.py", line 389, in __init__
        self.auth = base64.b64encode(user + ":" + password)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/base64.py", line 58, in b64encode
        encoded = binascii.b2a_base64(s, newline=False)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: a bytes-like object is required, not 'str'

The fix is to convert the authentication string to bytes before passing it to the base64 module, and then convert the result back to a string.