### PR TITLE
fix feedscanner crash with python >= 3.5

### DIFF
--- a/rawdoglib/feedscanner.py
+++ b/rawdoglib/feedscanner.py
@@ -40,6 +40,13 @@ import urllib.request, urllib.error, urllib.parse
 import urllib.parse
 import html.parser
 
+try:
+    # This exists in python <3.5, and in python <3.3 it could actually be raised.
+    from html.parser import HTMLParseError
+except ImportError:
+    # This is what python 3.11's html.parser does when given very broken HTML.
+    HTMLParseError = AssertionError
+
 def is_feed(url):
     """Return true if feedparser can understand the given URL as a feed."""
 
@@ -129,7 +136,7 @@ def feeds(page_url):
     parser = FeedFinder(page_url)
     try:
         parser.feed(data)
-    except html.parser.HTMLParseError:
+    except HTMLParseError:
         pass
     found = parser.urls()
 


### PR DESCRIPTION
In python 3.3, html.parser's "non-strict" mode, which never raises HTMLParseError, became the default. In python 3.5, the strict mode and the HTMLParseError class were both removed, causing the feed scanning code to crash.

The test suite contains [an example of HTML said to trigger a HTMLParseError](https://github.com/echarlie/rawdog-py3/blob/fa799c2e410a9d83877e81e4a61980f221dd3d1a/test-rawdog#L1834). With python 3.11 that HTML causes an AssertionError inside html.parser, so this commit falls back to catching AssertionError when HTMLParseError does not exist, so all python 3 versions should now behave correctly.

https://docs.python.org/3.3/library/html.parser.html#html.parser.HTMLParseError