### PR TITLE
port test suite to python3

### DIFF
--- a/test-rawdog
+++ b/test-rawdog
@@ -462,7 +462,7 @@ make_n () {
 fake_time () {
 	# A test can use this more than once within the same second, so the
 	# .pyc's timestamp might not change. Ensure it gets deleted.
-	rm -f $statedir/plugins/fake_time.*
+    	rm -f $statedir/plugins/__pycache__/fake_time.*
 	cat >$statedir/plugins/fake_time.py <<EOF
 import time
 def fake_time():
@@ -753,7 +753,7 @@ cat >$statedir/plugins/a.py <<EOF
 import rawdoglib.plugins
 def opt(config, name, value):
     if name == "testa":
-        print "saw-a"
+        print("saw-a")
         return False
     return True
 rawdoglib.plugins.attach_hook("config_option", opt)
@@ -762,7 +762,7 @@ cat >$statedir/plugins/b.py <<EOF
 import rawdoglib.plugins
 def opt(config, name, value):
     if name == "testb":
-        print "saw-b"
+        print("saw-b")
         return False
     return True
 rawdoglib.plugins.attach_hook("config_option", opt)
@@ -1516,7 +1516,7 @@ checkstatus () {
 import rawdoglib.plugins
 def feed_fetched(rawdog, config, feed, p, error, nf):
     if $1 not in [e['status'] for e in p['rawdog_responses']]:
-        print "didn't get HTTP $1 response"
+        print("didn't get HTTP $1 response")
 rawdoglib.plugins.attach_hook("feed_fetched", feed_fetched)
 EOF
 }


### PR DESCRIPTION
* run 2to3 on testserver.py and fix some bytes vs strings confusion.
* convert the print statements in test-rawdog to function calls.
* adjust test-rawdog to python 3's new bytecode location.

With these changes, the tests run, albeit with a number of failures, at least some of which look like genuine bugs.