### PR TITLE
fix feedscanner crash on gzip-compressed responses

### DIFF
--- a/rawdoglib/feedscanner.py
+++ b/rawdoglib/feedscanner.py
@@ -65,7 +65,7 @@ def fetch_url(url):
     encodings = headers.get("Content-Encoding", "")
     encodings = [s.strip() for s in encodings.split(",")]
     if "gzip" in encodings:
-        f = gzip.GzipFile(fileobj=io.StringIO(data))
+        f = gzip.GzipFile(fileobj=io.BytesIO(data))
         data = f.read()
         f.close()
 


### PR DESCRIPTION
2to3 generated a StringIO instance, but the data being read is bytes, causing a crash whenever a server returned gzip-encoded data.