### PR TITLE
fix bogus space characters when showing templates

### DIFF
--- a/rawdoglib/rawdog.py
+++ b/rawdoglib/rawdog.py
@@ -1590,7 +1590,7 @@ __feeditems__
 	def show_template(self, name, config):
 		"""Show the contents of a template, as currently configured."""
 		try:
-			print(self.get_template(config, name), end=' ')
+			print(self.get_template(config, name), end='')
 		except KeyError:
 			print("Unknown template name: " + name, file=sys.stderr)
 


### PR DESCRIPTION
When outputting templates using the "-s" or "--show" options, each template had a space character appended after its final newline. Thats's probably always harmless in practice, but it did make the test suite fail.

The extra space appeared because 2to3 converted `print foo,` to `print(foo, end=' ')`, which appends a space character to the output. That's usually close enough to the actual behaviour of python 2's print, but in this case python 2 would never output a space, because the template strings all end with a newline.

https://python.readthedocs.io/en/v2.7.2/reference/simple_stmts.html#print