### PR TITLE
Fix for python 3.13: remove "import cgi"

### DIFF
--- a/rawdoglib/rawdog.py
+++ b/rawdoglib/rawdog.py
@@ -25,7 +25,6 @@ from rawdoglib.plugins import Box, call_hook, load_plugins
 from io import StringIO
 import base64
 import calendar
-import cgi
 import feedparser
 import getopt
 import hashlib


### PR DESCRIPTION
The cgi module had been deprecated for a while but was removed in Python 3.13. echarlie did the heavy lifting to convert the code to use the html module so we just need to remove the "import cgi" so Rawdog can run on Python 3.13.