### PR TITLE
drop unused (and failling with python >= 3.13) import of cgi module

### DIFF
--- a/rawdoglib/rawdog.py
+++ b/rawdoglib/rawdog.py
@@ -25,7 +25,6 @@ from rawdoglib.plugins import Box, call_hook, load_plugins
 from io import StringIO
 import base64
 import calendar
-import cgi
 import feedparser
 import getopt
 import hashlib


### PR DESCRIPTION
Commit 2b44c9c already replaced all usages of this deprecated module, leaving only the import behind.

With python versions from 3.13 onward, this causes the error

    ModuleNotFoundError: No module named 'cgi'

Dropping the import makes things work again.